### PR TITLE
adds initial e2e-tests

### DIFF
--- a/e2e-tests/features/01-overview.js
+++ b/e2e-tests/features/01-overview.js
@@ -1,0 +1,65 @@
+// $ cd ecsrestaurantmenu/e2e-tests/
+
+// $ chimp --mocha --browser=firefox
+
+describe('overview page', function () {
+    var BASE_URL = 'http://ecsrestaurantmenu.apphb.com/';
+
+    before(function () {
+        browser.url(BASE_URL);
+
+        // wait for the page to load
+        browser.pause(3000);
+    });
+
+    describe('loading the page', function () {
+        it('should have the correct title', function () {
+            var title = browser.getTitle();
+            expect(title).to.equal('EC\'s Restaurant Menu');
+        });
+
+        it('should have the correct text for the navbar link', function () {
+            var selector = 'a.navbar-brand';
+            expect(browser.getText(selector)).to.equal('EC\'s Brick Oven & Grill');
+        });
+    });
+
+    describe('menu item headings', function () {
+        var selector = 'div.page h4';
+
+        var expectedItems = [
+            'Fudge Sundae',
+            'Roma Salad',
+            'Rosemary Chicken',
+            'Rowdy Rockport Fish Sandwich',
+            'Salmon Salad',
+            'Sweet Potato Tots',
+            'Tortilla Soup',
+            'Veggie Burger'
+        ];
+
+        var actualItems;
+
+        before(function () {
+            actualItems = browser.getText(selector);
+        });
+
+        // loop through the array of expected items;
+        // assert that the array of actual items includes each item
+        expectedItems.forEach(testFunction);
+
+        function testFunction(item) {
+            it('should include \'' + item + '\'', function () {
+                expect(actualItems).to.include(item);
+            });
+        }
+    });
+
+    describe('links', function () {
+        it('should have a \'Create New Menu Item\' button', function () {
+            var selector = '.btn-success';
+
+            expect(browser.getText(selector)).to.equal('Create New Menu Item');
+        });
+    });
+});

--- a/e2e-tests/features/02-create.js
+++ b/e2e-tests/features/02-create.js
@@ -1,0 +1,46 @@
+describe('create view', function () {
+    var BASE_URL = 'http://ecsrestaurantmenu.apphb.com/';
+
+    before(function () {
+        browser.url(BASE_URL);
+
+        // wait for the page to load
+        browser.pause(3000);
+    });
+
+    it('should navigate to \'New Menu Item\'', function () {
+        var selector = '.btn-success';
+        var heading;
+
+        browser.click(selector);
+        heading = browser.getText('h2');
+
+        expect(heading).to.equal('New Menu Item');
+    });
+
+    describe('input headings', function () {
+        var selector = 'div.page h4';
+
+        var expectedHeadings = [
+            'Name',
+            'Price',
+            'Picture URL'
+        ];
+
+        var actualHeadings;
+
+        before(function () {
+            actualHeadings = browser.getText(selector);
+        });
+
+        // loop through the array of expected headings;
+        // assert that the array of actual headings includes each heading
+        expectedHeadings.forEach(testFunction);
+
+        function testFunction(heading) {
+            it('should include \'' + heading + '\'', function () {
+                expect(actualHeadings).to.include(heading);
+            });
+        }
+    });
+});


### PR DESCRIPTION
```
~/code/ecsrestaurantmenu/e2e-tests (add-e2e-tests)
 ➜ chimp --mocha --browser=firefox

[chimp] Running...


  overview page
    loading the page
      ✓ should have the correct title
      ✓ should have the correct text for the navbar link
    menu item headings
      ✓ should include 'Fudge Sundae'
      ✓ should include 'Roma Salad'
      ✓ should include 'Rosemary Chicken'
      ✓ should include 'Rowdy Rockport Fish Sandwich'
      ✓ should include 'Salmon Salad'
      ✓ should include 'Sweet Potato Tots'
      ✓ should include 'Tortilla Soup'
      ✓ should include 'Veggie Burger'
    links
      ✓ should have a 'Create New Menu Item' button

  create view
    ✓ should navigate to 'New Menu Item'
    input headings
      ✓ should include 'Name'
      ✓ should include 'Price'
      ✓ should include 'Picture URL'


  15 passing (11s)
```

![screen shot 2016-07-07 at 11 52 53 pm](https://cloud.githubusercontent.com/assets/6632454/16677738/501ba1e6-449e-11e6-99ab-6087a5bce8e9.png)
